### PR TITLE
Syncronize Plugin Version with Assembly Version

### DIFF
--- a/ModelReplacementAPI/AssemblyInfo.cs
+++ b/ModelReplacementAPI/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using ModelReplacement;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle(PluginInfo.NAME)]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany(PluginInfo.WEBSITE)]
+[assembly: AssemblyProduct(PluginInfo.GUID)]
+[assembly: AssemblyCopyright("Copyright © meow 2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("Neutral")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6390E70C-AB5E-42ED-BA29-F173942DC3A9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion(PluginInfo.VERSION)]
+[assembly: AssemblyFileVersion(PluginInfo.VERSION)]

--- a/ModelReplacementAPI/ModelReplacementAPI.csproj
+++ b/ModelReplacementAPI/ModelReplacementAPI.csproj
@@ -7,6 +7,7 @@
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <LethalCompanyPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\</LethalCompanyPath>
   </PropertyGroup>
   

--- a/ModelReplacementAPI/ModelReplacementAPI_Plugin.cs
+++ b/ModelReplacementAPI/ModelReplacementAPI_Plugin.cs
@@ -13,9 +13,16 @@ using UnityEngine;
 namespace ModelReplacement
 {
 
+    internal static class PluginInfo
+    {
+        public const string GUID = "meow.ModelReplacementAPI";
+        public const string NAME = "ModelReplacementAPI";
+        public const string VERSION = "1.2.4";
+        public const string WEBSITE = "https://github.com/BunyaPineTree/LethalCompany_ModelReplacementAPI";
+    }
 
 
-    [BepInPlugin("meow.ModelReplacementAPI", "ModelReplacementAPI", "1.2.4")]
+    [BepInPlugin(PluginInfo.GUID, PluginInfo.NAME, PluginInfo.VERSION)]
     [BepInDependency("me.swipez.melonloader.morecompany", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("verity.3rdperson", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("LCThirdPerson", BepInDependency.DependencyFlags.SoftDependency)]


### PR DESCRIPTION
All this change does is make the assembly version be synchronized with the plugin version. It's mostly helpful when you have lots of assemblies lying around with the same name, but different versions. It will show the version number if you hover over the dll with your mouse in Windows Explorer.

If this change seems messy to you than it's perfectly acceptable to reject it.

Commits:
Setup AssemblyInfo.cs
The assembly's version will now be synchronized with the plugin version.