### PR TITLE
Update Material Replacement

### DIFF
--- a/ModelReplacementAPI/BodyReplacementBase.cs
+++ b/ModelReplacementAPI/BodyReplacementBase.cs
@@ -207,28 +207,28 @@ namespace ModelReplacement
             Renderer[] renderers = replacementModel.GetComponentsInChildren<Renderer>();
             Material gameMat = controller.thisPlayerModel.GetComponent<SkinnedMeshRenderer>().sharedMaterial;
             gameMat = new Material(gameMat); // Copy so that shared material isn't accidently changed by overriders of GetReplacementMaterial()
-			Dictionary<Material, Material> matMap = new();
+            Dictionary<Material, Material> matMap = new();
             List<Material> materials = ListPool<Material>.Get();
-			foreach (Renderer renderer in renderers)
-			{
-				renderer.GetSharedMaterials(materials);
-				for (int i = 0; i < materials.Count; i++)
+            foreach (Renderer renderer in renderers)
+            {
+                renderer.GetSharedMaterials(materials);
+                for (int i = 0; i < materials.Count; i++)
                 {
-					Material mat = materials[i];
-					if (!matMap.TryGetValue(mat, out var replacementMat))
+                    Material mat = materials[i];
+                    if (!matMap.TryGetValue(mat, out var replacementMat))
                     {
                         matMap[mat] = replacementMat = GetReplacementMaterial(gameMat, mat);
-					}
+                    }
                     materials[i] = replacementMat;
-				}
+                }
                 renderer.SetMaterials(materials);
             }
             ListPool<Material>.Release(materials);
 
 
 
-			//Set scripts missing from assetBundle
-			try
+            //Set scripts missing from assetBundle
+            try
             {
                 AddModelScripts();
             }
@@ -287,28 +287,29 @@ namespace ModelReplacement
             "Unlit/",
         };
 
-		/// <summary>
-		/// Get a replacement material based on the original game material, and the material found on the replacing model.
-		/// </summary>
-		/// <param name="gameMaterial">The equivalent material on the model being replaced.</param>
-		/// <param name="modelMaterial">The material on the replacing model.</param>
-		/// <returns>The replacement material created from the <see cref="gameMaterial"/> and the <see cref="modelMaterial"/></returns>
-		protected virtual Material GetReplacementMaterial(Material gameMaterial, Material modelMaterial)
+        /// <summary>
+        /// Get a replacement material based on the original game material, and the material found on the replacing model.
+        /// </summary>
+        /// <param name="gameMaterial">The equivalent material on the model being replaced.</param>
+        /// <param name="modelMaterial">The material on the replacing model.</param>
+        /// <returns>The replacement material created from the <see cref="gameMaterial"/> and the <see cref="modelMaterial"/></returns>
+        protected virtual Material GetReplacementMaterial(Material gameMaterial, Material modelMaterial)
         {
             if (shaderPrefixWhitelist.Any(prefix => modelMaterial.shader.name.StartsWith(prefix)))
             {
                 return modelMaterial;
-			}
+            }
             else
-			{
-				Material replacementMat = new Material(gameMaterial);
-				replacementMat.color = modelMaterial.color;
-				replacementMat.mainTexture = modelMaterial.mainTexture;
-				replacementMat.mainTextureOffset = modelMaterial.mainTextureOffset;
-				replacementMat.mainTextureScale = modelMaterial.mainTextureScale;
+            {
+                // XXX Ideally this material would be manually destroyed when the replacement model is destroyed.
+                Material replacementMat = new Material(gameMaterial);
+                replacementMat.color = modelMaterial.color;
+                replacementMat.mainTexture = modelMaterial.mainTexture;
+                replacementMat.mainTextureOffset = modelMaterial.mainTextureOffset;
+                replacementMat.mainTextureScale = modelMaterial.mainTextureScale;
                 return replacementMat;
-			}
-		}
+            }
+        }
 
         public void ReparentModel()
         {

--- a/ModelReplacementAPI/ModelReplacementAPI_Plugin.cs
+++ b/ModelReplacementAPI/ModelReplacementAPI_Plugin.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 namespace ModelReplacement
 {
 
-    internal static class PluginInfo
+    public static class PluginInfo
     {
         public const string GUID = "meow.ModelReplacementAPI";
         public const string NAME = "ModelReplacementAPI";


### PR DESCRIPTION
* Removed usage of material in favor of sharedMaterial
  * See the note on https://docs.unity3d.com/ScriptReference/Renderer-material.html
* Moved material conversion logic into protected virtual method GetReplacementMaterial() so users can override if necessary.
* Added shader whitelist for materials that don't need to be converted.