### PR TITLE
Fix lan and mirror

### DIFF
--- a/HatsuneMikuModelReplacement/Plugin.cs
+++ b/HatsuneMikuModelReplacement/Plugin.cs
@@ -79,7 +79,7 @@ namespace HatsuneMikuModelReplacement
         public static string mainAssetBundleName = "mbundle";
         public static AssetBundle MainAssetBundle = null;
 
-        private static string GetAssemblyName() => Assembly.GetExecutingAssembly().FullName.Split(',')[0];
+        private static string GetAssemblyName() => Assembly.GetExecutingAssembly().GetName().Name;
         public static void PopulateAssets()
         {
             if (MainAssetBundle == null)

--- a/ModelReplacementAPI/BodyReplacementBase.cs
+++ b/ModelReplacementAPI/BodyReplacementBase.cs
@@ -212,7 +212,6 @@ namespace ModelReplacement
             // Local/Nonlocal renderer logic
             if (!renderLocalDebug)
             {
-
                 if (RenderBodyReplacement()) {
                     SetRenderers(true);
                     SetPlayerControllerRenderers(false); // Don't render original body if non-local player
@@ -416,6 +415,10 @@ namespace ModelReplacement
         public bool RenderBodyReplacement()
         {
             if (!localPlayer) { return true; }
+            if (ModelReplacementAPI.mirrorDecorPresent)
+            {
+                return true; // Can just render because Mirror Decor sets models in a different layer
+            }
             if (ModelReplacementAPI.thirdPersonPresent)
             {
                 return DangerousViewState();
@@ -471,12 +474,14 @@ namespace ModelReplacement
         #region MirrorDecor Logic
         private void MirrorPatch()
         {
-            foreach (var item in replacementModel.GetComponentsInChildren<Renderer>())
+            if (localPlayer) // Only set our model to different layer, we still want to see others' models!
             {
-                item.shadowCastingMode = ShadowCastingMode.On;
-                item.gameObject.layer = 3;
+                foreach (var item in replacementModel.GetComponentsInChildren<Renderer>())
+                {
+                    item.shadowCastingMode = ShadowCastingMode.On;
+                    item.gameObject.layer = 23;
+                }
             }
-            if (localPlayer) { return; }
             if (ModelReplacementAPI.thirdPersonPresent)
             {
                 DangeroudFixCamera();
@@ -490,7 +495,7 @@ namespace ModelReplacement
         #region Third Person Mods Logic
         private void DangeroudFixCamera()
         {
-            ThirdPersonCamera.GetCamera.cullingMask = 557520887;
+            ThirdPersonCamera.GetCamera.cullingMask = 565909495;
         }
         private void DangeroudFixCameraLC()
         {

--- a/ModelReplacementAPI/BodyReplacementBase.cs
+++ b/ModelReplacementAPI/BodyReplacementBase.cs
@@ -215,15 +215,12 @@ namespace ModelReplacement
 
                 if (RenderBodyReplacement()) {
                     SetRenderers(true);
-                    controller.thisPlayerModel.enabled = false; // Don't render original body if non-local player
-                    controller.thisPlayerModelLOD1.enabled = false;
-                    controller.thisPlayerModelLOD2.enabled = false;
-                    nameTagObj.enabled = false;
-                    nameTagObj2.enabled = false;
+                    SetPlayerControllerRenderers(false); // Don't render original body if non-local player
                 }
                 else
                 {
                     SetRenderers(false); // Don't render model replacement if local player
+                    SetPlayerControllerRenderers(true);
                 }
             }
             else
@@ -401,6 +398,15 @@ namespace ModelReplacement
             {
                 renderer.enabled = enabled;
             }
+        }
+
+        private void SetPlayerControllerRenderers(bool enabled)
+        {
+            controller.thisPlayerModel.enabled = enabled;
+            controller.thisPlayerModelLOD1.enabled = enabled;
+            controller.thisPlayerModelLOD2.enabled = enabled;
+            nameTagObj.enabled = enabled;
+            nameTagObj2.enabled = enabled;
         }
 
         /// <summary>

--- a/ModelReplacementAPI/ModelReplacementAPI_Plugin.cs
+++ b/ModelReplacementAPI/ModelReplacementAPI_Plugin.cs
@@ -6,14 +6,11 @@ using HarmonyLib;
 using ModelReplacement.AvatarBodyUpdater;
 using System;
 using System.Collections.Generic;
-using BepInEx;
-using HarmonyLib;
 using UnityEngine;
 using System.Reflection;
 using ModelReplacement;
 using BepInEx.Configuration;
 
-using UnityEngine;
 using UnityEngine.TextCore.Text;
 using static UnityEngine.ParticleSystem.PlaybackState;
 //using System.Numerics;
@@ -285,8 +282,6 @@ namespace ModelReplacement
             {
                 try
                 {
-                    if (__instance.playerSteamId == 0) { return; }
-
                     var a = __instance.thisPlayerBody.gameObject.GetComponent<BodyReplacementBase>();
                     if ((a != null) && RegisteredModelReplacementExceptions.Contains(a.GetType()))
                     {


### PR DESCRIPTION
Now works in LAN (it was a single `if` statement).
Mirror is fixed, it also works with [3rdPerson](https://thunderstore.io/c/lethal-company/p/Verity/3rdPerson/) (solved issues #6 and #1 maybe?).
[LCThirdPerson](https://thunderstore.io/c/lethal-company/p/xboxcontroller/LCThirdPerson/) doesn't render model when [MirrorDecor](https://thunderstore.io/c/lethal-company/p/quackandcheese/MirrorDecor/) is used because it offsets the original camera and uses it, and the model is being rendered in a layer that the camera doesn't see, but the mirror does. The fix has to be done on their end (unless you want to constantly be changing layers / culling masks, idk :D)