### PR TITLE
Fixed exception on MaskedPlayerEnemy OnDestroy

### DIFF
--- a/ModelReplacementAPI/Monobehaviors/Enemies/MaskedReplacementBase.cs
+++ b/ModelReplacementAPI/Monobehaviors/Enemies/MaskedReplacementBase.cs
@@ -137,8 +137,10 @@ namespace ModelReplacement.Monobehaviors.Enemies
 
         protected virtual void OnDestroy()
         {
-            ModelReplacementAPI.Instance.Logger.LogInfo($"Destroy masked body component {replacementModel.name}");
-            Destroy(replacementModel);
+            if (replacementModel != null) {
+                ModelReplacementAPI.Instance.Logger.LogInfo($"Destroy masked body component {replacementModel.name}");
+                Destroy(replacementModel);
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes an exception if the `replacementModel` is `null`

```
NullReferenceException: Object reference not set to an instance of an object
  at ModelReplacement.Monobehaviors.Enemies.MaskedReplacementBase.OnDestroy () [0x00001] in <bdee04eb0b3f4377bcee7c264ff1616f>:IL_0001
```