### PR TITLE
Avoid adding Body Replacements to invalid PlayerControllerB components

### DIFF
--- a/ModelReplacementAPI/APIPlugin.cs
+++ b/ModelReplacementAPI/APIPlugin.cs
@@ -342,6 +342,9 @@ namespace ModelReplacement
 
             private static void ManageBodyReplacements(PlayerControllerB player)
             {
+                if (StartOfRound.Instance.allPlayerScripts[player.playerClientId] != player)
+                    return;
+
                 BodyReplacementBase currentReplacement = player.thisPlayerBody.gameObject.GetComponent<BodyReplacementBase>();
 
                 if (currentReplacement != null && RegisteredModelReplacementExceptions.Contains(currentReplacement.GetType()))


### PR DESCRIPTION
Fixes a rare edge-case where body replacements would be added to fake player controllers. Thus far this is only known to occur when GeneralImprovements causes the animation previewer from TooManyEmotes to change suits.