### PR TITLE
Special Item Compatibility Fix

### DIFF
--- a/ModelReplacementAPI/Monobehaviors/BodyReplacementBase.cs
+++ b/ModelReplacementAPI/Monobehaviors/BodyReplacementBase.cs
@@ -20,6 +20,7 @@ namespace ModelReplacement
 {
     public abstract class BodyReplacementBase : MonoBehaviour
     {
+        public static List<BodyReplacementBase> allBodies = new();
 
         //Base components
         public AvatarUpdater avatar { get; private set; }
@@ -407,7 +408,7 @@ namespace ModelReplacement
             target.bodyReplacement = this;
             target.modelObj = replacementModel;
 
-
+            allBodies.Add(this);
             ModelReplacementAPI.Instance.Logger.LogInfo($"AwakeEnd {controller.playerUsername}");
         }
 
@@ -448,7 +449,7 @@ namespace ModelReplacement
             ragdollAvatar.Update();
             viewModelAvatar.Update();
             cosmeticManager.UpdateModelReplacement();
-            UpdateItemTransform();
+            //UpdateItemTransform();
 
             //Bounding box calculation for nameTag
             if (replacementModel != null)
@@ -484,11 +485,27 @@ namespace ModelReplacement
             }
         }
 
+        static BodyReplacementBase()
+        {
+            RenderPipelineManager.beginContextRendering += ReallyLateUpdate;
+        }
+
+        public static void ReallyLateUpdate(ScriptableRenderContext context, List<Camera> cameras)
+        {
+            for (int i = 0; i < allBodies.Count; i++)
+            {
+                BodyReplacementBase body = allBodies[i];
+                if (!body || !body.isActiveAndEnabled) continue;
+                body.UpdateItemTransform();
+            }
+        }
 
 
         protected virtual void OnDestroy()
         {
             ModelReplacementAPI.Instance.Logger.LogInfo($"Destroy body component for {controller.playerUsername}");
+            allBodies.Remove(this);
+
             Destroy(replacementModel);
             Destroy(replacementModelShadow);
             Destroy(replacementViewModel);
@@ -501,7 +518,7 @@ namespace ModelReplacement
         public void UpdateItemTransform()
         {
             if (!heldItem) return;
-            if (heldItem.parentObject == null || heldItem.playerHeldBy != controller)
+            if (heldItem.parentObject == null || heldItem.playerHeldBy != controller || controller.ItemSlots[controller.currentItemSlot] != heldItem)
             {
                 heldItem = null;
                 return;
@@ -509,35 +526,28 @@ namespace ModelReplacement
 
             bool inFirstPerson = viewState.GetViewState() == ViewState.FirstPerson;
 
-            Vector3 rootPos;
-            Quaternion rootRot;
             if(inFirstPerson)
             {
-                rootPos = controller.localItemHolder.position;
-                rootRot = controller.localItemHolder.rotation;
-
                 if(heldItem.itemProperties.twoHandedAnimation)
-                    rootPos += (viewModelAvatar.ItemOffsetLeft + viewModelAvatar.ItemOffsetRight) / 2;
+                    heldItem.transform.Translate((viewModelAvatar.ItemOffsetLeft + viewModelAvatar.ItemOffsetRight) / 2, Space.World);
                 else
-                    rootPos += viewModelAvatar.ItemOffsetRight;
+                    heldItem.transform.Translate(viewModelAvatar.ItemOffsetRight, Space.World);
             }
             else
             {
-                rootPos = controller.serverItemHolder.position;
-                rootRot = controller.serverItemHolder.rotation;
+                if (viewState.localPlayer)
+                {
+                    // Reset transform to serverItemHolder position
+                    heldItem.transform.rotation = controller.serverItemHolder.rotation;
+                    heldItem.transform.Rotate(heldItem.itemProperties.rotationOffset);
+                    heldItem.transform.position = controller.serverItemHolder.position + controller.serverItemHolder.rotation * heldItem.itemProperties.positionOffset;
+                }
 
                 if(heldItem.itemProperties.twoHandedAnimation)
-                    rootPos += (avatar.ItemOffsetLeft + avatar.ItemOffsetRight) / 2;
+                    heldItem.transform.Translate((avatar.ItemOffsetLeft + avatar.ItemOffsetRight) / 2, Space.World);
                 else
-                    rootPos += avatar.ItemOffsetRight;
+                    heldItem.transform.Translate(avatar.ItemOffsetRight, Space.World);
             }
-
-            heldItem.transform.rotation = rootRot;
-            heldItem.transform.Rotate(heldItem.itemProperties.rotationOffset);
-            heldItem.transform.position = rootPos;
-            Vector3 vector = heldItem.itemProperties.positionOffset;
-            vector = rootRot * vector;
-            heldItem.transform.position += vector;
 
             // Update jetpack backpack
             if(heldItem is JetpackItem jet)
@@ -545,10 +555,8 @@ namespace ModelReplacement
                 Quaternion baseRot = avatar.lowerSpine.rotation * avatar.jetpackRotOffset;
 
                 jet.backPart.rotation = baseRot;
-                heldItem.transform.Rotate(jet.backPartRotationOffset); // This is heldItem instead of backPart intentionally
-                jet.backPart.position = avatar.lowerSpine.position;
-                vector = baseRot * jet.backPartPositionOffset;
-                jet.backPart.position += vector;
+                jet.backPart.Rotate(jet.backPartRotationOffset);
+                jet.backPart.position = avatar.lowerSpine.position + baseRot * jet.backPartPositionOffset;
             }
         }
         #endregion

--- a/ModelReplacementAPI/Monobehaviors/BodyReplacementBase.cs
+++ b/ModelReplacementAPI/Monobehaviors/BodyReplacementBase.cs
@@ -498,19 +498,16 @@ namespace ModelReplacement
         #endregion
 
         #region items
-        public bool CanPositionItemOnCustomViewModel => (replacementViewModel != null);
         public void UpdateItemTransform()
         {
             if (!heldItem) return;
-            if (heldItem.parentObject == null || heldItem.playerHeldBy == null) return;
-            if (heldItem.playerHeldBy != controller)
+            if (heldItem.parentObject == null || heldItem.playerHeldBy != controller)
             {
                 heldItem = null;
                 return;
             }
 
             bool inFirstPerson = viewState.GetViewState() == ViewState.FirstPerson;
-            if(inFirstPerson && !CanPositionItemOnCustomViewModel) return;
 
             Vector3 rootPos;
             Quaternion rootRot;
@@ -526,21 +523,13 @@ namespace ModelReplacement
             }
             else
             {
+                rootPos = controller.serverItemHolder.position;
+                rootRot = controller.serverItemHolder.rotation;
+
                 if(heldItem.itemProperties.twoHandedAnimation)
-                {
-                    rootPos = controller.serverItemHolder.position;
-                    rootRot = controller.serverItemHolder.rotation;
-
                     rootPos += (avatar.ItemOffsetLeft + avatar.ItemOffsetRight) / 2;
-                }
                 else
-                {
-                    // Copy the local transform from the localItemHolder to replicate anims for things like knives
-                    rootPos = controller.serverItemHolder.parent.TransformPoint(controller.localItemHolder.localPosition);
-                    rootRot = controller.serverItemHolder.parent.rotation * controller.localItemHolder.localRotation;
-
                     rootPos += avatar.ItemOffsetRight;
-                }
             }
 
             heldItem.transform.rotation = rootRot;

--- a/ModelReplacementAPI/Patches/HeldItemPositionPatch.cs
+++ b/ModelReplacementAPI/Patches/HeldItemPositionPatch.cs
@@ -9,20 +9,17 @@ namespace ModelReplacement.Patches
     {
 
         [HarmonyPatch("LateUpdate")]
-        [HarmonyPrefix]
-        public static bool LateUpdatePatch(ref GrabbableObject __instance)
+        [HarmonyPostfix]
+        public static void LateUpdatePatch(ref GrabbableObject __instance)
         {
-            if (__instance.parentObject == null || __instance.playerHeldBy == null) return true;
-            if (__instance.playerHeldBy.ItemSlots[__instance.playerHeldBy.currentItemSlot] != __instance) return true;
+            if (__instance.parentObject == null || __instance.playerHeldBy == null) return;
+            if (__instance.playerHeldBy.ItemSlots[__instance.playerHeldBy.currentItemSlot] != __instance) return;
 
             BodyReplacementBase bodyReplacement = __instance.playerHeldBy.gameObject.GetComponent<BodyReplacementBase>();
-            if (!bodyReplacement) return true;
+            if (!bodyReplacement) return;
 
             if (bodyReplacement.heldItem != __instance)
                 bodyReplacement.heldItem = __instance;
-
-            return false;
-
         }
     }
 }

--- a/ModelReplacementAPI/Patches/HeldItemPositionPatch.cs
+++ b/ModelReplacementAPI/Patches/HeldItemPositionPatch.cs
@@ -18,13 +18,6 @@ namespace ModelReplacement.Patches
             BodyReplacementBase bodyReplacement = __instance.playerHeldBy.gameObject.GetComponent<BodyReplacementBase>();
             if (!bodyReplacement) return true;
 
-            if(!bodyReplacement.CanPositionItemOnCustomViewModel || bodyReplacement.viewState.GetViewState() != ViewState.FirstPerson)
-            {
-                if (bodyReplacement.heldItem != null)
-                    bodyReplacement.heldItem = null;
-                return true;
-            }
-
             if (bodyReplacement.heldItem != __instance)
                 bodyReplacement.heldItem = __instance;
 

--- a/ModelReplacementAPI/Scripts/Player/AvatarUpdater.cs
+++ b/ModelReplacementAPI/Scripts/Player/AvatarUpdater.cs
@@ -76,6 +76,7 @@ namespace ModelReplacement.AvatarBodyUpdater
 
         protected virtual void UpdateModel()
         {
+            replacement.transform.SetPositionAndRotation(playerModelRenderer.transform.position,playerModelRenderer.transform.rotation);
             Transform rootBone = GetAvatarTransformFromBoneName("spine");
             Transform playerRootBone = GetPlayerTransformFromBoneName("spine");
             rootBone.position = playerRootBone.position + playerRootBone.TransformVector(rootPositionOffset);


### PR DESCRIPTION
Avoids skipping the LateUpdate method on your currently held item and moves UpdateItemTransform to a new delegate that runs right before rendering but after every LateUpdate. Should fix the belt bag and possibly some other items.