### PR TITLE
Fix NullReferenceException completely breaking the player death animation

### DIFF
--- a/ModelReplacementAPI/Patches/PlayerControllerBPatch.cs
+++ b/ModelReplacementAPI/Patches/PlayerControllerBPatch.cs
@@ -67,11 +67,15 @@ namespace ModelReplacement.Patches
         [HarmonyPostfix]
         public static void SpawnDeadBody(int playerId, Vector3 bodyVelocity, int causeOfDeath, PlayerControllerB deadPlayerController, int deathAnimation = 0, Transform overridePosition = null, Vector3 positionOffset = default(Vector3))
         {
-            var renderers = deadPlayerController.deadBody.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
-            deadPlayerController.deadBody.gameObject.layer = ViewStateManager.ragdollLayer;
-            foreach (var renderer in renderers)
-            {
-                //renderer.gameObject.layer = ViewStateManager.visibleLayer;
+            try {
+                var renderers = deadPlayerController.deadBody.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
+                deadPlayerController.deadBody.gameObject.layer = ViewStateManager.ragdollLayer;
+                foreach (var renderer in renderers)
+                {
+                    //renderer.gameObject.layer = ViewStateManager.visibleLayer;
+                }
+            } catch (NullReferenceException e) {
+                Debug.LogError(e);
             }
         }
     }


### PR DESCRIPTION
A simple try-catch fixes the issue for now, a proper fix might be better.

fixes #143 